### PR TITLE
Read Strip URI from Ingress Annotationsg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ build-local:
 	export SHELL=/bin/sh
 	rm -rf ${BINARY_DEST_DIR}
 	mkdir -p ${BINARY_DEST_DIR}
-	env GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags ${LDFLAGS} -o ${BINARY_DEST_DIR}/kong-ingress cmd/main.go
+	env GOOS=${GOOS} GOARCH=${GOARCH} go build -i -ldflags ${LDFLAGS} -o ${BINARY_DEST_DIR}/kong-ingress cmd/main.go
 
 docker-build:
-	docker build --rm -t ${IMAGE} rootfs
+	docker build --rm -t ${IMAGE} .
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 test-unit:

--- a/docs/examples/install.yaml
+++ b/docs/examples/install.yaml
@@ -13,7 +13,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: koli-controller
-        image: 'quay.io/koli/kong-ingress:v0.2.1-alpha'
+        image: 'salemove/kong-ingress'
         args:
         - --auto-claim
         - --wipe-on-delete

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"reflect"
 	"time"
+  "strconv"
 
 	"github.com/golang/glog"
 	"kolihub.io/kong-ingress/pkg/kong"
@@ -313,11 +314,19 @@ func (k *KongController) syncIngress(key string, numRequeues int) error {
 				return fmt.Errorf("failed listing api: %s", resp)
 			}
 
+      stripUri, err := strconv.ParseBool(ing.Annotations["ingress.kubernetes.io/strip-uri"])
+      if err != nil {
+        stripUri = false
+        glog.Infof("Failed to parse strip-uri annotation, setting it to false")
+      }
+
 			apiBody := &kong.API{
 				Name:        apiName,
 				Hosts:       []string{r.Host},
 				UpstreamURL: upstreamURL,
+        StripUri:   stripUri,
 			}
+
 			if p.Path != "" {
 				apiBody.URIs = []string{pathURI}
 			}

--- a/pkg/kong/types.go
+++ b/pkg/kong/types.go
@@ -122,6 +122,7 @@ type API struct {
 	PreserveHost bool      `json:"preserve_host"`
 	UpstreamURL  string    `json:"upstream_url"`
 	CreatedAt    Timestamp `json:"created_at,omitempty"`
+  StripUri     bool      `json:"strip_uri"`
 }
 
 // APIList is a list of API's

--- a/versioning.mk
+++ b/versioning.mk
@@ -3,15 +3,15 @@ VERSION ?= unknown
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 DATE ?= $(shell date -u "+%Y-%m-%dT%H:%M:%SZ")
 
-KOLI_REGISTRY ?= quay.io/
-IMAGE_PREFIX ?= koli
+REGISTRY ?= docker.io/
+IMAGE_PREFIX ?= salemove
 
-IMAGE := ${KOLI_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
-MUTABLE_IMAGE := ${KOLI_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${MUTABLE_VERSION}
+IMAGE := ${REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
+MUTABLE_IMAGE := ${REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${MUTABLE_VERSION}
 
 info:
 	@echo "Build tag:       ${VERSION}"
-	@echo "Registry:        ${KOLI_REGISTRY}"
+	@echo "Registry:        ${REGISTRY}"
 	@echo "Immutable tag:   ${IMAGE}"
 	@echo "Mutable tag:     ${MUTABLE_IMAGE}"
 


### PR DESCRIPTION
[Strip URI](https://getkong.org/docs/0.10.x/proxy/) It may be desirable to specify a URI prefix to match an API,
but not include it in the upstream request.

It means that if the request is '/omnicall/path' it removes the
'/omnicall' piece, which is not desired.

The default value is `true`. This PR reads the value from the
ingress annotations. E.g.

```
annotations:
  ingress.kubernetes.io/strip-uri: "[true|false]"
```

I'll add a test and make a PR to the upstream