### PR TITLE
Configure Strip URI parameter for a set of API Objects via Ingress Annotations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 The controller watches for ingress endpoints and provisions Kong routes based on the ingress spec. It's only allowed to do so when all the domains are claimed for each host found in the ingress resource. A negative response generates a warning as a Kubernetes Event.
 
-Each host could have multiple paths endpoints with multiple services backends, the controller validates if a service exists for each path. The full URI of the service is used as the `upstream_url` when creating a route in Kong. 
+Each host could have multiple paths endpoints with multiple services backends, the controller validates if a service exists for each path. The full URI of the service is used as the `upstream_url` when creating a route in Kong.
 
 When an API is created by the controller it's identified following the convention: `[host]~[namespace]~[path-hash]`
 
@@ -165,6 +165,31 @@ metadata:
     kolihub.io/parent: acme-project
 spec:
   rules:
+  - host: coyote.acme.org
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: web
+          servicePort: 80
+```
+
+### Configure a set of API Objects via Ingress Resource Annotations
+A set of API Objects managed and exposed by Kong can be configured by annotating Ingress resources.
+
+#### Configurating the `strip_uri` property
+The [`strip_uri`](https://getkong.org/docs/0.10.x/proxy/#the-strip_uri-property) property determines whether or not to strip a matching prefix from the upstream URI to be requested. The default value is `true` but it might not be the desire behavior in all cases. To set the `strip_uri` property for a set of APIs an annotation is required.
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: coyote-acme-org
+  annotations:
+    ingress.kubernetes.io/strip-uri: "false"
+spec:
+  rules:
+  # this host will generate a domain claim as primary!
   - host: coyote.acme.org
     http:
       paths:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"reflect"
 	"time"
+  	"strconv"
 
 	"github.com/golang/glog"
 	"kolihub.io/kong-ingress/pkg/kong"
@@ -320,10 +321,17 @@ func (k *KongController) syncIngress(key string, numRequeues int) error {
 				return fmt.Errorf("failed listing api: %s", resp)
 			}
 
+		      	stripUri, err := strconv.ParseBool(ing.Annotations["ingress.kubernetes.io/strip-uri"])
+		      	if err != nil {
+		        	stripUri = true
+		        	glog.Infof("Failed to parse strip-uri annotation, setting it to the default value true")
+		      	}
+
 			apiBody := &kong.API{
 				Name:        apiName,
 				Hosts:       []string{r.Host},
 				UpstreamURL: upstreamURL,
+        			StripUri:    stripUri,
 			}
 			if p.Path != "" {
 				apiBody.URIs = []string{pathURI}

--- a/pkg/kong/types.go
+++ b/pkg/kong/types.go
@@ -119,6 +119,7 @@ type API struct {
 	PreserveHost bool      `json:"preserve_host"`
 	UpstreamURL  string    `json:"upstream_url"`
 	CreatedAt    Timestamp `json:"created_at,omitempty"`
+  	StripUri     bool      `json:"strip_uri"`
 }
 
 // APIList is a list of API's


### PR DESCRIPTION
The [`strip_uri`](https://getkong.org/docs/0.10.x/proxy/#the-strip_uri-property) property determines whether or not to strip a
matching prefix from the upstream URI to be requested. The default value is `true`
but it might not be the desire behavior in all cases.

This PR enables an Ingress Resource to be annotated as

```
...
annotations:
  ingress.kubernetes.io/strip-uri: "[false | true]"
```

The controller then reads this annotation and uses its value while creating
the different API objects via Kong Admin.