### PR TITLE
Add preserve-host annotation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -198,3 +198,6 @@ spec:
           serviceName: web
           servicePort: 80
 ```
+
+#### Configurating the `preserve_host` property
+When proxying, Kong's default behavior is to set the upstream request's Host header to the hostname of the API's upstream_url property. The [`preserve_host`](https://getkong.org/docs/0.10.x/proxy/#the-preserve_host-property) field accepts a boolean flag instructing Kong not to do so. Default value is false.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strconv"
 	"time"
-  	"strconv"
 
 	"github.com/golang/glog"
 	"kolihub.io/kong-ingress/pkg/kong"
@@ -321,17 +321,17 @@ func (k *KongController) syncIngress(key string, numRequeues int) error {
 				return fmt.Errorf("failed listing api: %s", resp)
 			}
 
-		      	stripUri, err := strconv.ParseBool(ing.Annotations["ingress.kubernetes.io/strip-uri"])
-		      	if err != nil {
-		        	stripUri = true
-		        	glog.Infof("Failed to parse strip-uri annotation, setting it to the default value true")
-		      	}
+			stripUri, err := strconv.ParseBool(ing.Annotations["ingress.kubernetes.io/strip-uri"])
+			if err != nil {
+				stripUri = true
+				glog.Infof("Failed to parse strip-uri annotation, setting it to the default value true")
+			}
 
 			apiBody := &kong.API{
 				Name:        apiName,
 				Hosts:       []string{r.Host},
 				UpstreamURL: upstreamURL,
-        			StripUri:    stripUri,
+				StripUri:    stripUri,
 			}
 			if p.Path != "" {
 				apiBody.URIs = []string{pathURI}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -327,11 +327,18 @@ func (k *KongController) syncIngress(key string, numRequeues int) error {
 				glog.Infof("Failed to parse strip-uri annotation, setting it to the default value true")
 			}
 
+			preserveHost, err := strconv.ParseBool(ing.Annotations["ingress.kubernetes.io/preserve-host"])
+			if err != nil {
+				preserveHost = false
+				glog.Infof("Failed to parse preserve-host annotation, setting it to the default value false")
+			}
+
 			apiBody := &kong.API{
-				Name:        apiName,
-				Hosts:       []string{r.Host},
-				UpstreamURL: upstreamURL,
-				StripUri:    stripUri,
+				Name:         apiName,
+				Hosts:        []string{r.Host},
+				UpstreamURL:  upstreamURL,
+				StripUri:     stripUri,
+				PreserveHost: preserveHost,
 			}
 			if p.Path != "" {
 				apiBody.URIs = []string{pathURI}


### PR DESCRIPTION
When proxying, Kong's default behavior is to set the upstream request's Host
header to the hostname of the API's upstream_url property. The
[`preserve_host`](https://getkong.org/docs/0.10.x/proxy/#the-preserve_host-property)
field accepts a boolean flag instructing Kong not to do so. Default value is
false.